### PR TITLE
Change references to class methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ This lab involves building a basic ORM for a Dog object.  The `Dog` class define
 
   The `#initialize` method accepts a hash or keyword argument value with key-value pairs as an argument. key-value pairs need to contain id, name, and breed.
 
--  **`::create_table`**
+-  **`.create_table`**
   Your task  here is to define a class method on Dog that will execute the correct SQL to create a dogs table.
 
 ```ruby
-describe '::create_table' do
+describe '.create_table' do
   it 'creates a dogs table' do
     DB[:conn].execute('DROP TABLE IF EXISTS dogs')
     Dog.create_table
@@ -44,11 +44,11 @@ end
 
   Next we call the soon to be defined `create_table` method, which is responsible for creating a table called dogs with the appropriate columns.
 
--  **`::drop_table`**
+-  **`.drop_table`**
 This method will drop the dogs table from the database.
 
 ```ruby
-  describe '::drop_table' do
+  describe '.drop_table' do
     it "drops the dogs table" do
         Dog.drop_table
 
@@ -60,11 +60,11 @@ This method will drop the dogs table from the database.
 
   It is basically the exact opposite of the previous test. Your job is to define a class method on `Dog` that will execute the correct SQL to drop a dogs table.
 
-- **`::new_from_db`**
+- **`.new_from_db`**
 
-  This is an interesting method. Ultimately, the database is going to return an array representing a dog's data. We need a way to cast that data into the appropriate attributes of a dog. This method encapsulates that functionality. You can even think of it as  `new_from_array`. Methods like this, that return instances of the class, are known as constructors, just like `::new`, except that they extend the functionality of `::new` without overwriting `initialize`.
+  This is an interesting method. Ultimately, the database is going to return an array representing a dog's data. We need a way to cast that data into the appropriate attributes of a dog. This method encapsulates that functionality. You can even think of it as  `new_from_array`. Methods like this, that return instances of the class, are known as constructors, just like `.new`, except that they extend the functionality of `.new` without overwriting `initialize`.
 
-- **`::find_by_name`**
+- **`.find_by_name`**
 
   This spec will first insert a dog into the database and then attempt to find it by calling the find_by_name method. The expectations are that an instance of the dog class that has all the properties of a dog is returned, not primitive data.
 

--- a/spec/dog_spec.rb
+++ b/spec/dog_spec.rb
@@ -37,7 +37,7 @@ describe "Dog" do
     end
   end
 
-  describe "::create_table" do
+  describe ".create_table" do
     it 'creates the dogs table in the database' do
       Dog.create_table
       table_check_sql = "SELECT tbl_name FROM sqlite_master WHERE type='table' AND tbl_name='dogs';"
@@ -45,7 +45,7 @@ describe "Dog" do
     end
   end
 
-  describe "::drop_table" do
+  describe ".drop_table" do
     it 'drops the dogs table from the database' do
       Dog.drop_table
       table_check_sql = "SELECT tbl_name FROM sqlite_master WHERE type='table' AND tbl_name='dogs';"
@@ -68,7 +68,7 @@ describe "Dog" do
     end
   end
 
-  describe "::create" do
+  describe ".create" do
     it 'takes in a hash of attributes and uses metaprogramming to create a new dog object. Then it uses the #save method to save that dog to the database'do
       Dog.create(name: "Ralph", breed: "lab")
       expect(DB[:conn].execute("SELECT * FROM dogs")).to eq([[1, "Ralph", "lab"]])
@@ -81,7 +81,7 @@ describe "Dog" do
     end
   end
 
-  describe '::find_by_id' do
+  describe '.find_by_id' do
     it 'returns a new dog object by id' do
       dog = Dog.create(name: "Kevin", breed: "shepard")
 
@@ -91,7 +91,7 @@ describe "Dog" do
     end
   end
 
-  describe '::find_or_create_by' do
+  describe '.find_or_create_by' do
     it 'creates an instance of a dog if it does not already exist' do
       dog1 = Dog.create(name: 'teddy', breed: 'cockapoo')
       dog2 = Dog.find_or_create_by(name: 'teddy', breed: 'cockapoo')
@@ -117,7 +117,7 @@ describe "Dog" do
     end
   end
 
-  describe '::new_from_db' do
+  describe '.new_from_db' do
     it 'creates an instance with corresponding attribute values' do
       row = [1, "Pat", "poodle"]
       pat = Dog.new_from_db(row)
@@ -128,7 +128,7 @@ describe "Dog" do
     end
   end
 
-  describe '::find_by_name' do
+  describe '.find_by_name' do
     it 'returns an instance of dog that matches the name from the DB' do
       teddy.save
       teddy_from_db = Dog.find_by_name("Teddy")


### PR DESCRIPTION
Change all the references to class methods in the test and readme. Previously, they were referenced with namespacing `::`. I change it to `.` to be more consistent with the rest of the curriculum. 